### PR TITLE
Feature/join

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ blueworld/local_settings.py
 blueworld/static/foundation/
 blueworld/staticfiles/
 ghostdriver.log
+lathermail.db

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,21 @@ language: python
 python:
 - "3.5"
 cache: pip
-install: "pip install -r requirements.txt -r requirements/dev.txt"
+install: "pip install -r requirements.txt -r requirements/test.txt"
 services:
 - postgresql
 before_script:
+- "lathermail > log_lathermail.txt 2>&1 &"
 - psql -c 'CREATE DATABASE blueworld;' -U postgres
 - psql -c "CREATE USER blueworld with password 'blueworld'" -U postgres
 - psql -c 'GRANT ALL PRIVILEGES ON DATABASE blueworld TO blueworld;' -U postgres
 - python manage.py makemigrations
 - python manage.py migrate
 - echo "from django.contrib.auth.models import User; User.objects.create_superuser('superuser', 'james@3aims.com', '123123ab')" | python manage.py shell
-- python manage.py runserver 0.0.0.0:8000 &
+- "python manage.py runserver 0.0.0.0:8000 > log_runserver.txt 2>&1 &"
+- "curl -0 -H 'X-Mail-Password: password' http://127.0.0.1:5000/api/0/messages/"
 - sleep 8
 script: behave
+after_script:
+- cat log_runserver.txt
+- cat log_lathermail.txt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blueworld Lite
 
-[![Build Status](https://travis-ci.org/productscience/blue-world-lite.svg?branch=master)](https://travis-ci.org/productscience/blue-world-lite)
+[![Build Status](https://travis-ci.org/productscience/blue-world-lite.svg)](https://travis-ci.org/productscience/blue-world-lite)
 [![Requirements Status](https://requires.io/github/productscience/blue-world-lite/requirements.svg?branch=feature%2Fjoin)](https://requires.io/github/productscience/blue-world-lite/requirements/?branch=feature%2Fjoin)
 [![License: Apache 2](https://img.shields.io/badge/license-Apache%202-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -36,7 +36,13 @@ Set up environment variables:
 export DJANGO_SETTINGS_MODULE='blueworld.settings'
 export DATABASE_URL='postgres://blueworld:blueworld@localhost:5432/blueworld'
 export DEBUG='True'
+export EMAIL_HOST='smtp.sendgrid.net'
+export EMAIL_HOST_USER='blue-world-lite'
 export EMAIL_HOST_PASSWORD='xxx'
+export EMAIL_PORT=587
+export EMAIL_USE_TLS='True'
+export DEFAULT_FROM_EMAIL='no-reply@blueworld.example.com'
+export SERVER_EMAIL='error@blueworld.example.com'
 ```
 
 Set up a virtual environment and install run dependencies:
@@ -72,7 +78,13 @@ Make sure you have the Heroku toolbelt installed then create a `.env` file with 
 DJANGO_SETTINGS_MODULE='blueworld.settings'
 DATABASE_URL='postgres://blueworld:blueworld@localhost:5432/blueworld'
 DEBUG='True'
+EMAIL_HOST='smtp.sendgrid.net'
+EMAIL_HOST_USER='blue-world-lite'
 EMAIL_HOST_PASSWORD='xxx'
+EMAIL_PORT=587
+EMAIL_USE_TLS='True'
+DEFAULT_FROM_EMAIL='no-reply@blueworld.example.com'
+SERVER_EMAIL='error@blueworld.example.com'
 ```
 
 Now run like this:
@@ -95,12 +107,13 @@ git checkout <branch>
 git push heroku HEAD:master
 ```
 
-Then set up the production config by running:
+Then set up the production config by running similar commands for each of the settings in `.env`. e.g.:
 
 ```
 heroku config:set DJANGO_SETTINGS_MODULE=blueworld.settings
 heroku config:set DEBUG=False
 heroku config:set DATABASE_URL=...
+... 
 ```
 
 Then run:
@@ -193,43 +206,6 @@ export DEFAULT_FROM_EMAIL='no-reply@blueworld.example.com'
 export SERVER_EMAIL='error@blueworld.example.com'
 ```
 
-## Setting up `maildump` (deprecated)
-
-You need Python 2 for this.
-
-```
-virtualenv .ve2
-.ve2/bin/pip install maildump
-.ve2/bin/maildump --help
-```
-
-You can get started like this:
-
-```
-$ .ve2/bin/maildump 
-[2016-06-09 10:08:46]  NOTICE    maildump: Starting web server on http://127.0.0.1:1080
-[2016-06-09 10:08:46]  NOTICE    maildump: Starting smtp server on 127.0.0.1:1025
-[2016-06-09 10:08:46]  INFO      maildump.db: Using database :memory:
-...
-```
-
-Set up Django by setting these environment variables and restarting the server:
-
-```
-export EMAIL_HOST='localhost'
-export EMAIL_HOST_USER=''
-export EMAIL_HOST_PASSWORD=''
-export EMAIL_PORT=1025
-export EMAIL_USE_TLS='False'
-export DEFAULT_FROM_EMAIL='no-reply@blueworld.example.com'
-export SERVER_EMAIL='error@blueworld.example.com'
-```
-
-Now emails sent from Django will appear in the web interface at http://127.0.0.1:1080
-
-There is also a fairly RESTFul API allowing you to download a list of messages in JSON from /messages, each message's metadata with /messages/:id.json, and then the pertinent parts with /messages/:id.html and /messages/:id.plain for the default HTML and plain text version, /messages/:id/:cid for individual attachments by CID, or the whole message with /messages/:id.source.
-
-
 ## Setting up `lathermail`
 
 ```
@@ -315,7 +291,6 @@ You need to configure the following environment variables in the Travis interfac
 * `DJANGO_SETTINGS_MODULE` blueworld.settings
 * `DATABASE_URL` postgres://blueworld:blueworld@localhost:5432/blueworld
 * `DEBUG` False
-* `EMAIL_BACKEND` django.core.mail.backends.locmem.EmailBackend
 * `DEFAULT_FROM_EMAIL` no-reply@blueworld.example.com
 * `SERVER_EMAIL` error@blueworld.example.com
 * `ALLOWED_HOSTS` localhost, 127.0.0.1
@@ -323,10 +298,12 @@ You need to configure the following environment variables in the Travis interfac
 
 ## Setting up PaperTrail
 
-Todo.
+```
+heroku drains:add syslog+tls://logs2.papertrailapp.com:<YOURPORT> --app blueworld`
+```
 
 ## Dev and Test
 
 ```
-pip install -r requirements/dev.txt
+pip install -r requirements.txt -r requirements/dev.txt -r requirements/test.txt
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Blueworld Lite
 
 [![Build Status](https://travis-ci.org/productscience/blue-world-lite.svg?branch=master)](https://travis-ci.org/productscience/blue-world-lite)
+[![Requirements Status](https://requires.io/github/productscience/blue-world-lite/requirements.svg?branch=feature%2Fjoin)](https://requires.io/github/productscience/blue-world-lite/requirements/?branch=feature%2Fjoin)
 [![License: Apache 2](https://img.shields.io/badge/license-Apache%202-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
 This is a Django project that handles management and billing of a Growing
@@ -192,9 +193,120 @@ export DEFAULT_FROM_EMAIL='no-reply@blueworld.example.com'
 export SERVER_EMAIL='error@blueworld.example.com'
 ```
 
-## Setting up `maildump`
+## Setting up `maildump` (deprecated)
 
-Todo.
+You need Python 2 for this.
+
+```
+virtualenv .ve2
+.ve2/bin/pip install maildump
+.ve2/bin/maildump --help
+```
+
+You can get started like this:
+
+```
+$ .ve2/bin/maildump 
+[2016-06-09 10:08:46]  NOTICE    maildump: Starting web server on http://127.0.0.1:1080
+[2016-06-09 10:08:46]  NOTICE    maildump: Starting smtp server on 127.0.0.1:1025
+[2016-06-09 10:08:46]  INFO      maildump.db: Using database :memory:
+...
+```
+
+Set up Django by setting these environment variables and restarting the server:
+
+```
+export EMAIL_HOST='localhost'
+export EMAIL_HOST_USER=''
+export EMAIL_HOST_PASSWORD=''
+export EMAIL_PORT=1025
+export EMAIL_USE_TLS='False'
+export DEFAULT_FROM_EMAIL='no-reply@blueworld.example.com'
+export SERVER_EMAIL='error@blueworld.example.com'
+```
+
+Now emails sent from Django will appear in the web interface at http://127.0.0.1:1080
+
+There is also a fairly RESTFul API allowing you to download a list of messages in JSON from /messages, each message's metadata with /messages/:id.json, and then the pertinent parts with /messages/:id.html and /messages/:id.plain for the default HTML and plain text version, /messages/:id/:cid for individual attachments by CID, or the whole message with /messages/:id.source.
+
+
+## Setting up `lathermail`
+
+```
+lathermail --db-uri sqlite:////$D/lathermail.db
+```
+
+Set up Django by setting these environment variables and restarting the server:
+
+```
+export EMAIL_HOST='localhost'
+export EMAIL_HOST_USER='user'
+export EMAIL_HOST_PASSWORD='password'
+export EMAIL_PORT=2525
+export EMAIL_USE_TLS='False'
+export DEFAULT_FROM_EMAIL='no-reply@blueworld.example.com'
+export SERVER_EMAIL='error@blueworld.example.com'
+```
+
+Latermail has a concept of different inboxes based on SMTP logins. Above we used `user` and `password` so lathermail sets up an inbox with these when it receives the first mail.
+
+Now emails sent from Django will appear in the web interface at http://127.0.0.1:5000. 
+
+To use the API you need to set some headers for the inbox you are after like this:
+
+```
+$ curl -0 -H "X-Mail-Password: password" http://127.0.0.1:5000/api/0/inboxes/
+{
+    "inbox_list": [
+        "user"
+    ],
+    "inbox_count": 1
+}
+$ curl -0 -H "X-Mail-Password: password" http://127.0.0.1:5000/api/0/messages/
+{
+    "message_count": 1,
+    "message_list": [
+        {
+            "recipients": [
+                {
+                    "address": "james@jimmyg.org",
+                    "name": ""
+                }
+            ],
+            "read": true,
+            "recipients_raw": "james@jimmyg.org",
+            "created_at": "2016-06-09T10:32:29.489615+00:00",
+            "sender": {
+                "address": "no-reply@blueworld.example.com",
+                "name": ""
+            },
+            "subject": "[example.com] Please Confirm Your E-mail Address",
+            "inbox": "user",
+            "sender_raw": "no-reply@blueworld.example.com",
+            "password": "password",
+            "message_raw": ...
+            "parts": [
+                {
+                    "type": "text/plain",
+                    "size": 337,
+                    "filename": null,
+                    "charset": "utf-8",
+                    "index": 0,
+                    "is_attachment": false,
+                    "body": ...
+                }
+            ],
+            "_id": "0c110b02-ac30-4d1a-b181-27f6f9526f23"
+        }
+    ]
+}
+$ curl -0 -H "X-Mail-Password: password" http://127.0.0.1:5000/api/0/messages/0c110b02-ac30-4d1a-b181-27f6f9526f23
+... Same content as the message above ...
+```
+
+You can also get attachments, and delete messages. See https://github.com/reclosedev/lathermail.
+
+With the config described above, the data is stored in an SQLite database too.
 
 ## Setting up Travis
 

--- a/blueworld/settings.py
+++ b/blueworld/settings.py
@@ -172,6 +172,6 @@ EMAIL_USE_TLS = not str(os.environ.get('EMAIL_USE_TLS')).lower() == 'false'
 # EMAIL_USE_SSL = True
 DEFAULT_FROM_EMAIL = os.environ['DEFAULT_FROM_EMAIL']
 SERVER_EMAIL = os.environ['SERVER_EMAIL']
-EMAIL_BACKEND = os.environ.get('EMAIL_BACKEND', 'django.core.mail.backends.filebased.EmailBackend')
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 if os.environ.get('ALLOWED_HOSTS'):
     ALLOWED_HOSTS += [host.strip() for host in os.environ['ALLOWED_HOSTS'].split(',')]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,2 @@
-behave==1.2.5
 docutils==0.12
-selenium==2.53.2
 Sphinx==1.4.3
-browserstep==0.1.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,0 +1,4 @@
+behave==1.2.5
+selenium==2.53.4
+browserstep==0.1.0
+lathermail==0.2.0


### PR DESCRIPTION
We've got:
- a `lathermail` server running on Travis now for testing email output in future
- server and lathermail output separate from behave output
- a requires.io button on the README to keep dependencies up to date
- documentation in the README of the core lathermail API
- no need to make EMAIL_BACKEND configurable - we always use SMTP, even locally now
